### PR TITLE
Fix NPM package repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "signcode-tf",
   "version": "0.7.4",
-  "description": "Sign Windows executables from a Mac",
+  "description": "Sign Windows executables from a Windows or MacOS",
   "repository": "https://github.com/develar/signcode",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "signcode-tf",
   "version": "0.7.4",
-  "description": "Sign Windows executables from a Windows or MacOS",
+  "description": "Sign Windows executables from Windows or MacOS",
   "repository": "https://github.com/develar/signcode",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "signcode-tf",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Sign Windows executables from a Mac",
-  "repository": "https://github.com/kevinsawicki/signcode",
+  "repository": "https://github.com/develar/signcode",
   "main": "index.js",
   "scripts": {
     "test": "mocha && standard"


### PR DESCRIPTION
When you go to https://www.npmjs.com/package/signcode-tf, it's currently pointing to the wrong code base.
